### PR TITLE
Uses buildpack.toml config in integration suite

### DIFF
--- a/integration/caching_test.go
+++ b/integration/caching_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/paketo-buildpacks/occam"
@@ -61,7 +62,7 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[firstImage.ID] = struct{}{}
 
 			Expect(firstImage.Buildpacks).To(HaveLen(2))
-			Expect(firstImage.Buildpacks[1].Key).To(Equal("paketo-buildpacks/npm"))
+			Expect(firstImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 			Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
 			container, err := docker.Container.Run.Execute(firstImage.ID)
@@ -77,7 +78,7 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[secondImage.ID] = struct{}{}
 
 			Expect(secondImage.Buildpacks).To(HaveLen(2))
-			Expect(secondImage.Buildpacks[1].Key).To(Equal("paketo-buildpacks/npm"))
+			Expect(secondImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 			Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
 			container, err = docker.Container.Run.Execute(secondImage.ID)
@@ -104,7 +105,7 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[firstImage.ID] = struct{}{}
 
 			Expect(firstImage.Buildpacks).To(HaveLen(2))
-			Expect(firstImage.Buildpacks[1].Key).To(Equal("paketo-buildpacks/npm"))
+			Expect(firstImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 			Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
 			container, err := docker.Container.Run.Execute(firstImage.ID)
@@ -120,7 +121,7 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[secondImage.ID] = struct{}{}
 
 			Expect(secondImage.Buildpacks).To(HaveLen(2))
-			Expect(secondImage.Buildpacks[1].Key).To(Equal("paketo-buildpacks/npm"))
+			Expect(secondImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 			Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
 			container, err = docker.Container.Run.Execute(secondImage.ID)
@@ -148,7 +149,7 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[firstImage.ID] = struct{}{}
 
 			Expect(firstImage.Buildpacks).To(HaveLen(2))
-			Expect(firstImage.Buildpacks[1].Key).To(Equal("paketo-buildpacks/npm"))
+			Expect(firstImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 			Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
 			container, err := docker.Container.Run.Execute(firstImage.ID)
@@ -164,7 +165,7 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 			imageIDs[secondImage.ID] = struct{}{}
 
 			Expect(secondImage.Buildpacks).To(HaveLen(2))
-			Expect(secondImage.Buildpacks[1].Key).To(Equal("paketo-buildpacks/npm"))
+			Expect(secondImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 			Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
 			container, err = docker.Container.Run.Execute(secondImage.ID)
@@ -182,7 +183,7 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(logs).To(ContainLines(
-				fmt.Sprintf("NPM Buildpack %s", buildpackVersion),
+				fmt.Sprintf("%s %s", buildpackInfo.Buildpack.Name, buildpackVersion),
 				"  Resolving installation process",
 				"    Process inputs:",
 				"      node_modules      -> \"Found\"",
@@ -191,7 +192,7 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 				"",
 				MatchRegexp(`    Selected NPM build process:`),
 				"",
-				"  Reusing cached layer /layers/paketo-buildpacks_npm/modules",
+				fmt.Sprintf("  Reusing cached layer /layers/%s/modules", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 			))
 		})
 	})

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"github.com/paketo-buildpacks/occam"
 	"github.com/paketo-buildpacks/packit/pexec"
 	"github.com/sclevine/spec"
@@ -22,6 +23,12 @@ var (
 	npmCachedURI  string
 	nodeURI       string
 	nodeCachedURI string
+	buildpackInfo struct {
+		Buildpack struct {
+			ID   string
+			Name string
+		}
+	}
 )
 
 func TestIntegration(t *testing.T) {
@@ -34,11 +41,17 @@ func TestIntegration(t *testing.T) {
 		NodeEngine string `json:"node-engine"`
 	}
 
-	file, err := os.Open("./../integration.json")
+	file, err := os.Open("../integration.json")
 	Expect(err).NotTo(HaveOccurred())
 	defer file.Close()
 
 	Expect(json.NewDecoder(file).Decode(&config)).To(Succeed())
+
+	file, err = os.Open("../buildpack.toml")
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = toml.DecodeReader(file, &buildpackInfo)
+	Expect(err).NotTo(HaveOccurred())
 
 	root, err := filepath.Abs("./..")
 	Expect(err).NotTo(HaveOccurred())

--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/paketo-buildpacks/occam"
@@ -56,7 +57,7 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(logs).To(ContainLines(
-				fmt.Sprintf("NPM Buildpack %s", buildpackVersion),
+				fmt.Sprintf("%s %s", buildpackInfo.Buildpack.Name, buildpackVersion),
 				"  Resolving installation process",
 				"    Process inputs:",
 				"      node_modules      -> \"Not found\"",
@@ -72,7 +73,7 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				"  Configuring environment",
 				"    NPM_CONFIG_LOGLEVEL   -> \"error\"",
 				"    NPM_CONFIG_PRODUCTION -> \"true\"",
-				"    PATH                  -> \"$PATH:/layers/paketo-buildpacks_npm/modules/node_modules/.bin\"",
+				fmt.Sprintf("    PATH                  -> \"$PATH:/layers/%s/modules/node_modules/.bin\"", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 			))
 		})
 	})


### PR DESCRIPTION
Instead of hardcoding these values, we are parameterizing them and reading them from the buildpack.toml so that if they change, the test suite does not need to change.