### PR TITLE
Buildpack should only run "npm install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,31 @@
-# NPM Cloud Native Buildpack
+# Paketo NPM Install Cloud Native Buildpack
 
-The NPM CNB makes use of the [`npm`](https://www.npmjs.com/) tooling installed
-within the [Node Engine CNB](https://github.com/paketo-buildpacks/node-engine)
-to manage application dependencies, then writes the start command for the given
-application.
+The NPM Install CNB makes use of the [`npm`](https://www.npmjs.com/) tooling
+installed within the [Node Engine CNB](https://github.com/paketo-buildpacks/node-engine)
+to manage application dependencies.
 
 ## Integration
 
-The NPM CNB provides node_modules as a dependency. Downstream buildpacks can
-require the node dependency by generating a [Build Plan
-TOML](https://github.com/buildpacks/spec/blob/master/buildpack.md#build-plan-toml)
+The NPM Install CNB provides `node_modules` as a dependency. Downstream
+buildpacks can require the `node_modules` dependency by generating a [Build
+Plan TOML](https://github.com/buildpacks/spec/blob/master/buildpack.md#build-plan-toml)
 file that looks like the following:
 
 ```toml
 [[requires]]
 
-  # The name of the NPM dependency is "node_modules". This value is considered
-  # part of the public API for the buildpack and will not change without a plan
-  # for deprecation.
+  # The name of the NPM Install dependency is "node_modules". This value is
+  # considered part of the public API for the buildpack and will not change
+  # without a plan for deprecation.
   name = "node_modules"
 
   # Note: The version field is unsupported as there is no version for a set of
   # npm.
 
-  # The NPM buildpack supports some non-required metadata options.
+  # The NPM Install buildpack supports some non-required metadata options.
   [requires.metadata]
 
-    # Setting the build flag to true will ensure that the Node modules are
+    # Setting the build flag to true will ensure that the node modules are
     # available for subsequent buildpacks during their build phase.
     # If you are writing a buildpack that needs to run a node module during its build
     # process, this flag should be set to true.
@@ -34,7 +33,7 @@ file that looks like the following:
 
     # Setting the launch flag to true will ensure that the packages managed by
     # NPM will be available for the running application. If you
-    # are writing an application that needs to run Node modules at runtime, this
+    # are writing an application that needs to run node modules at runtime, this
     # flag should be set to true.
     launch = true
 ```
@@ -47,8 +46,6 @@ To package this buildpack for consumption:
 $ ./scripts/package.sh
 ```
 
-This builds the buildpack's Go source using `GOOS=linux` by default. You can supply another value as the first argument to `package.sh`.
-
 ## `buildpack.yml` Configurations
 
-The `npm` buildpack does not support configurations using `buildpack.yml`.
+The NPM Install buildpack does not support configurations using `buildpack.yml`.

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,9 +1,9 @@
 api = "0.2"
 
 [buildpack]
-id = "paketo-buildpacks/npm"
-name = "Paketo NPM Buildpack"
-homepage = "https://github.com/paketo-buildpacks/npm"
+id = "paketo-buildpacks/npm-install"
+name = "Paketo NPM Install Buildpack"
+homepage = "https://github.com/paketo-buildpacks/npm-install"
 
 [metadata]
 include_files = [ "bin/build", "bin/detect", "bin/run", "buildpack.toml" ]

--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,10 @@
+package npm
+
+const (
+	NodeModules = "node_modules"
+	Node        = "node"
+	Npm         = "npm"
+
+	LayerNameNodeModules = "modules"
+	LayerNameCache       = "npm-cache"
+)

--- a/detect.go
+++ b/detect.go
@@ -8,11 +8,6 @@ import (
 	"github.com/paketo-buildpacks/packit"
 )
 
-const (
-	PlanDependencyNodeModules = "node_modules"
-	PlanDependencyNode        = "node"
-)
-
 type BuildPlanMetadata struct {
 	Version       string `toml:"version"`
 	VersionSource string `toml:"version-source"`
@@ -37,10 +32,9 @@ func Detect(packageJSONParser VersionParser) packit.DetectFunc {
 		}
 
 		nodeDependency := packit.BuildPlanRequirement{
-			Name: PlanDependencyNode,
+			Name: Node,
 			Metadata: BuildPlanMetadata{
-				Build:  true,
-				Launch: true,
+				Build: true,
 			},
 		}
 
@@ -49,18 +43,22 @@ func Detect(packageJSONParser VersionParser) packit.DetectFunc {
 				Version:       version,
 				VersionSource: "package.json",
 				Build:         true,
-				Launch:        true,
 			}
 		}
 
 		return packit.DetectResult{
 			Plan: packit.BuildPlan{
 				Provides: []packit.BuildPlanProvision{
-					{Name: PlanDependencyNodeModules},
+					{Name: NodeModules},
 				},
 				Requires: []packit.BuildPlanRequirement{
-					{Name: PlanDependencyNodeModules},
 					nodeDependency,
+					{
+						Name: Npm,
+						Metadata: BuildPlanMetadata{
+							Build: true,
+						},
+					},
 				},
 			},
 		}, nil

--- a/detect_test.go
+++ b/detect_test.go
@@ -35,17 +35,21 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Plan).To(Equal(packit.BuildPlan{
 			Provides: []packit.BuildPlanProvision{
-				{Name: npm.PlanDependencyNodeModules},
+				{Name: npm.NodeModules},
 			},
 			Requires: []packit.BuildPlanRequirement{
-				{Name: npm.PlanDependencyNodeModules},
 				{
-					Name: npm.PlanDependencyNode,
+					Name: npm.Node,
 					Metadata: npm.BuildPlanMetadata{
 						Version:       "1.2.3",
 						VersionSource: "package.json",
 						Build:         true,
-						Launch:        true,
+					},
+				},
+				{
+					Name: npm.Npm,
+					Metadata: npm.BuildPlanMetadata{
+						Build: true,
 					},
 				},
 			},
@@ -66,15 +70,19 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Plan).To(Equal(packit.BuildPlan{
 				Provides: []packit.BuildPlanProvision{
-					{Name: npm.PlanDependencyNodeModules},
+					{Name: npm.NodeModules},
 				},
 				Requires: []packit.BuildPlanRequirement{
-					{Name: npm.PlanDependencyNodeModules},
 					{
-						Name: npm.PlanDependencyNode,
+						Name: npm.Node,
 						Metadata: npm.BuildPlanMetadata{
-							Build:  true,
-							Launch: true,
+							Build: true,
+						},
+					},
+					{
+						Name: npm.Npm,
+						Metadata: npm.BuildPlanMetadata{
+							Build: true,
 						},
 					},
 				},

--- a/integration.json
+++ b/integration.json
@@ -1,4 +1,5 @@
 {
   "builder": "index.docker.io/paketobuildpacks/builder:full-cf",
+  "build-plan": "github.com/ForestEckhardt/build-plan",
   "node-engine": "github.com/paketo-buildpacks/node-engine"
 }

--- a/integration/caching_test.go
+++ b/integration/caching_test.go
@@ -59,18 +59,18 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 			source, err = occam.Source(filepath.Join("testdata", "simple_app"))
 			Expect(err).NotTo(HaveOccurred())
 
-			build := pack.Build.WithNoPull().WithBuildpacks(nodeURI, npmURI)
+			build := pack.Build.WithNoPull().WithBuildpacks(nodeURI, buildpackURI, buildPlanURI)
 
 			firstImage, logs, err := build.Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String)
 
 			imageIDs[firstImage.ID] = struct{}{}
 
-			Expect(firstImage.Buildpacks).To(HaveLen(2))
+			Expect(firstImage.Buildpacks).To(HaveLen(3))
 			Expect(firstImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 			Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
-			container, err := docker.Container.Run.Execute(firstImage.ID)
+			container, err := docker.Container.Run.WithCommand("npm start").Execute(firstImage.ID)
 			Expect(err).NotTo(HaveOccurred())
 
 			containerIDs[container.ID] = struct{}{}
@@ -82,11 +82,11 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 
 			imageIDs[secondImage.ID] = struct{}{}
 
-			Expect(secondImage.Buildpacks).To(HaveLen(2))
+			Expect(secondImage.Buildpacks).To(HaveLen(3))
 			Expect(secondImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 			Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
-			container, err = docker.Container.Run.Execute(secondImage.ID)
+			container, err = docker.Container.Run.WithCommand("npm start").Execute(secondImage.ID)
 			Expect(err).NotTo(HaveOccurred())
 
 			containerIDs[container.ID] = struct{}{}
@@ -104,14 +104,14 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 			source, err = occam.Source(filepath.Join("testdata", "locked_app"))
 			Expect(err).NotTo(HaveOccurred())
 
-			build := pack.Build.WithNoPull().WithBuildpacks(nodeURI, npmURI)
+			build := pack.Build.WithNoPull().WithBuildpacks(nodeURI, buildpackURI, buildPlanURI)
 
 			firstImage, logs, err := build.Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String)
 
 			imageIDs[firstImage.ID] = struct{}{}
 
-			Expect(firstImage.Buildpacks).To(HaveLen(2))
+			Expect(firstImage.Buildpacks).To(HaveLen(3))
 			Expect(firstImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 			Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
@@ -135,7 +135,7 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 				fmt.Sprintf("    PATH                  -> \"$PATH:/layers/%s/modules/node_modules/.bin\"", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 			))
 
-			container, err := docker.Container.Run.Execute(firstImage.ID)
+			container, err := docker.Container.Run.WithCommand("npm start").Execute(firstImage.ID)
 			Expect(err).NotTo(HaveOccurred())
 
 			containerIDs[container.ID] = struct{}{}
@@ -147,11 +147,11 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 
 			imageIDs[secondImage.ID] = struct{}{}
 
-			Expect(secondImage.Buildpacks).To(HaveLen(2))
+			Expect(secondImage.Buildpacks).To(HaveLen(3))
 			Expect(secondImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 			Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
-			container, err = docker.Container.Run.Execute(secondImage.ID)
+			container, err = docker.Container.Run.WithCommand("npm start").Execute(secondImage.ID)
 			Expect(err).NotTo(HaveOccurred())
 
 			containerIDs[container.ID] = struct{}{}
@@ -170,18 +170,18 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 			source, err = occam.Source(filepath.Join("testdata", "vendored"))
 			Expect(err).NotTo(HaveOccurred())
 
-			build := pack.WithNoColor().Build.WithNoPull().WithBuildpacks(nodeURI, npmURI)
+			build := pack.WithNoColor().Build.WithNoPull().WithBuildpacks(nodeURI, buildpackURI, buildPlanURI)
 
 			firstImage, logs, err := build.Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String)
 
 			imageIDs[firstImage.ID] = struct{}{}
 
-			Expect(firstImage.Buildpacks).To(HaveLen(2))
+			Expect(firstImage.Buildpacks).To(HaveLen(3))
 			Expect(firstImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 			Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
-			container, err := docker.Container.Run.Execute(firstImage.ID)
+			container, err := docker.Container.Run.WithCommand("npm start").Execute(firstImage.ID)
 			Expect(err).NotTo(HaveOccurred())
 
 			containerIDs[container.ID] = struct{}{}
@@ -193,11 +193,11 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 
 			imageIDs[secondImage.ID] = struct{}{}
 
-			Expect(secondImage.Buildpacks).To(HaveLen(2))
+			Expect(secondImage.Buildpacks).To(HaveLen(3))
 			Expect(secondImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 			Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
-			container, err = docker.Container.Run.Execute(secondImage.ID)
+			container, err = docker.Container.Run.WithCommand("npm start").Execute(secondImage.ID)
 			Expect(err).NotTo(HaveOccurred())
 
 			containerIDs[container.ID] = struct{}{}

--- a/integration/empty_node_modules_test.go
+++ b/integration/empty_node_modules_test.go
@@ -44,7 +44,11 @@ func testEmptyNodeModules(t *testing.T, context spec.G, it spec.S) {
 
 			_, logs, err := pack.Build.
 				WithNoPull().
-				WithBuildpacks(nodeURI, npmURI).
+				WithBuildpacks(
+					nodeURI,
+					buildpackURI,
+					buildPlanURI,
+				).
 				Execute(name, source)
 			Expect(err).To(HaveOccurred())
 

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -16,11 +16,12 @@ import (
 )
 
 var (
-	npmURI        string
-	npmCachedURI  string
-	nodeURI       string
-	nodeCachedURI string
-	buildpackInfo struct {
+	buildpackURI        string
+	buildpackOfflineURI string
+	nodeURI             string
+	nodeOfflineURI      string
+	buildPlanURI        string
+	buildpackInfo       struct {
 		Buildpack struct {
 			ID   string
 			Name string
@@ -36,6 +37,7 @@ func TestIntegration(t *testing.T) {
 
 	var config struct {
 		NodeEngine string `json:"node-engine"`
+		BuildPlan  string `json:"build-plan"`
 	}
 
 	file, err := os.Open("../integration.json")
@@ -55,12 +57,12 @@ func TestIntegration(t *testing.T) {
 
 	buildpackStore := occam.NewBuildpackStore()
 
-	npmURI, err = buildpackStore.Get.
+	buildpackURI, err = buildpackStore.Get.
 		WithVersion("1.2.3").
 		Execute(root)
 	Expect(err).ToNot(HaveOccurred())
 
-	npmCachedURI, err = buildpackStore.Get.
+	buildpackOfflineURI, err = buildpackStore.Get.
 		WithOfflineDependencies().
 		WithVersion("1.2.3").
 		Execute(root)
@@ -70,10 +72,14 @@ func TestIntegration(t *testing.T) {
 		Execute(config.NodeEngine)
 	Expect(err).ToNot(HaveOccurred())
 
-	nodeCachedURI, err = buildpackStore.Get.
+	nodeOfflineURI, err = buildpackStore.Get.
 		WithOfflineDependencies().
 		Execute(config.NodeEngine)
 	Expect(err).ToNot(HaveOccurred())
+
+	buildPlanURI, err = buildpackStore.Get.
+		Execute(config.BuildPlan)
+	Expect(err).NotTo(HaveOccurred())
 
 	SetDefaultEventuallyTimeout(10 * time.Second)
 

--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -55,7 +55,11 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
 				WithNoPull().
-				WithBuildpacks(nodeURI, npmURI).
+				WithBuildpacks(
+					nodeURI,
+					buildpackURI,
+					buildPlanURI,
+				).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String)
 

--- a/integration/no_node_modules_test.go
+++ b/integration/no_node_modules_test.go
@@ -58,11 +58,15 @@ func testNoNodeModules(t *testing.T, context spec.G, it spec.S) {
 
 			image, _, err = pack.Build.
 				WithNoPull().
-				WithBuildpacks(nodeURI, npmURI).
+				WithBuildpacks(
+					nodeURI,
+					buildpackURI,
+					buildPlanURI,
+				).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
-			container, err = docker.Container.Run.Execute(image.ID)
+			container, err = docker.Container.Run.WithCommand("npm start").Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(container).Should(BeAvailable())

--- a/integration/npmrc_test.go
+++ b/integration/npmrc_test.go
@@ -55,7 +55,11 @@ func testNpmrc(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithBuildpacks(nodeCachedURI, npmCachedURI).
+				WithBuildpacks(
+					nodeOfflineURI,
+					buildpackOfflineURI,
+					buildPlanURI,
+				).
 				WithNoPull().
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String)

--- a/integration/pre_post_scripts_test.go
+++ b/integration/pre_post_scripts_test.go
@@ -58,13 +58,17 @@ func testPrePostScriptRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithBuildpacks(nodeCachedURI, npmCachedURI).
+				WithBuildpacks(
+					nodeOfflineURI,
+					buildpackURI,
+					buildPlanURI,
+				).
 				WithNoPull().
 				WithNetwork("none").
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String)
 
-			container, err = docker.Container.Run.Execute(image.ID)
+			container, err = docker.Container.Run.WithCommand("npm start").Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(container).Should(BeAvailable())

--- a/integration/testdata/empty_node_modules/plan.toml
+++ b/integration/testdata/empty_node_modules/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "node_modules"
+
+  [requires.metadata]
+    launch = true

--- a/integration/testdata/locked_app/plan.toml
+++ b/integration/testdata/locked_app/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "node_modules"
+
+  [requires.metadata]
+    launch = true

--- a/integration/testdata/no_node_modules/plan.toml
+++ b/integration/testdata/no_node_modules/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "node_modules"
+
+  [requires.metadata]
+    launch = true

--- a/integration/testdata/npmrc/plan.toml
+++ b/integration/testdata/npmrc/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "node_modules"
+
+  [requires.metadata]
+    launch = true

--- a/integration/testdata/pre_post_scripts_vendored/plan.toml
+++ b/integration/testdata/pre_post_scripts_vendored/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "node_modules"
+
+  [requires.metadata]
+    launch = true

--- a/integration/testdata/simple_app/plan.toml
+++ b/integration/testdata/simple_app/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "node_modules"
+
+  [requires.metadata]
+    launch = true

--- a/integration/testdata/unmet_dep/plan.toml
+++ b/integration/testdata/unmet_dep/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "node_modules"
+
+  [requires.metadata]
+    launch = true

--- a/integration/testdata/vendored/plan.toml
+++ b/integration/testdata/vendored/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "node_modules"
+
+  [requires.metadata]
+    launch = true

--- a/integration/testdata/with_nvmrc/plan.toml
+++ b/integration/testdata/with_nvmrc/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "node_modules"
+
+  [requires.metadata]
+    launch = true

--- a/integration/testdata/with_nvmrc_and_no_engine/plan.toml
+++ b/integration/testdata/with_nvmrc_and_no_engine/plan.toml
@@ -1,0 +1,5 @@
+[[requires]]
+  name = "node_modules"
+
+  [requires.metadata]
+    launch = true

--- a/integration/unmet_dependencies_test.go
+++ b/integration/unmet_dependencies_test.go
@@ -44,7 +44,11 @@ func testUnmetDependencies(t *testing.T, context spec.G, it spec.S) {
 
 			_, logs, err := pack.Build.
 				WithNoPull().
-				WithBuildpacks(nodeURI, npmURI).
+				WithBuildpacks(
+					nodeURI,
+					buildpackURI,
+					buildPlanURI,
+				).
 				Execute(name, source)
 			Expect(err).To(HaveOccurred())
 			Expect(logs).To(ContainSubstring("vendored node_modules have unmet dependencies"))

--- a/integration/vendored_test.go
+++ b/integration/vendored_test.go
@@ -63,11 +63,15 @@ func testVendored(t *testing.T, context spec.G, it spec.S) {
 
 			image, logs, err = pack.Build.
 				WithNoPull().
-				WithBuildpacks(nodeURI, npmURI).
+				WithBuildpacks(
+					nodeURI,
+					buildpackURI,
+					buildPlanURI,
+				).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
-			container, err = docker.Container.Run.Execute(image.ID)
+			container, err = docker.Container.Run.WithCommand("npm start").Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(container).Should(BeAvailable())
@@ -108,12 +112,16 @@ func testVendored(t *testing.T, context spec.G, it spec.S) {
 				var err error
 				image, _, err = pack.Build.
 					WithNoPull().
-					WithBuildpacks(nodeCachedURI, npmCachedURI).
+					WithBuildpacks(
+						nodeOfflineURI,
+						buildpackOfflineURI,
+						buildPlanURI,
+					).
 					WithNetwork("none").
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred())
 
-				container, err = docker.Container.Run.Execute(image.ID)
+				container, err = docker.Container.Run.WithCommand("npm start").Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(container).Should(BeAvailable())

--- a/integration/vendored_with_binaries_test.go
+++ b/integration/vendored_with_binaries_test.go
@@ -59,7 +59,11 @@ func testVendoredWithBinaries(t *testing.T, context spec.G, it spec.S) {
 			var logs fmt.Stringer
 			image, logs, err = pack.WithVerbose().WithNoColor().Build.
 				WithNoPull().
-				WithBuildpacks(nodeURI, npmURI).
+				WithBuildpacks(
+					nodeURI,
+					buildpackURI,
+					buildPlanURI,
+				).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String)
 

--- a/integration/versioning_test.go
+++ b/integration/versioning_test.go
@@ -61,11 +61,11 @@ func testVersioning(t *testing.T, context spec.G, it spec.S) {
 
 			image, _, err = pack.Build.
 				WithNoPull().
-				WithBuildpacks(nodeURI, npmURI).
+				WithBuildpacks(nodeURI, buildpackURI, buildPlanURI).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred())
 
-			container, err = docker.Container.Run.Execute(image.ID)
+			container, err = docker.Container.Run.WithCommand("npm start").Execute(image.ID)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(container).Should(BeAvailable())
@@ -89,11 +89,11 @@ func testVersioning(t *testing.T, context spec.G, it spec.S) {
 
 			image, _, err = pack.Build.
 				WithNoPull().
-				WithBuildpacks(nodeURI, npmURI).
+				WithBuildpacks(nodeURI, buildpackURI, buildPlanURI).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred())
 
-			container, err = docker.Container.Run.Execute(image.ID)
+			container, err = docker.Container.Run.WithCommand("npm start").Execute(image.ID)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(container).Should(BeAvailable())


### PR DESCRIPTION
Previously it set the start cmd as "npm start",
and marked the layers launch/build/cache without
considering the metadata passed to it by the downstream
consumer.

This follows the proposal in
[Nodejs RFC
0001](https://github.com/paketo-buildpacks/nodejs/blob/main/rfcs/0001-buildpacks-architecture.md)

Co-Authored-by: Arjun Sreedharan <asreedharan@vmware.com>
Co-Authored-by: Tim Hitchener <thitchener@vmware.com>

Resolves #109 