### PR TITLE
Do not stick build time env var value to launch

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -23,16 +23,19 @@ func NewEnvironment(logger scribe.Logger) Environment {
 }
 
 func (e Environment) Configure(layer packit.Layer) error {
-	for envvar := range e.defaultValues {
-		layer.LaunchEnv.Default(envvar, e.GetValue(envvar))
+	for envvar, val := range e.defaultValues {
+		layer.LaunchEnv.Default(envvar, val)
 	}
 
 	path := filepath.Join(layer.Path, "node_modules", ".bin")
 	layer.SharedEnv.Append("PATH", path, string(os.PathListSeparator))
 
-	e.logger.Process("Configuring environment")
+	e.logger.Process("Configuring launch environment")
 	e.logger.Subprocess("%s", scribe.NewFormattedMapFromEnvironment(layer.LaunchEnv))
+	e.logger.Break()
+	e.logger.Process("Configuring environment shared by build and launch")
 	e.logger.Subprocess("%s", scribe.NewFormattedMapFromEnvironment(layer.SharedEnv))
+	e.logger.Break()
 
 	return nil
 }

--- a/environment_test.go
+++ b/environment_test.go
@@ -2,6 +2,7 @@ package npminstall_test
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -57,6 +58,12 @@ func testEnvironment(t *testing.T, context spec.G, it spec.S) {
 				"PATH.append": filepath.Join(layer.Path, "node_modules", ".bin"),
 				"PATH.delim":  string(os.PathListSeparator),
 			}))
+
+			Expect(buffer.String()).To(ContainSubstring("  Configuring launch environment"))
+			Expect(buffer.String()).To(ContainSubstring("    NPM_CONFIG_LOGLEVEL -> \"error\""))
+			Expect(buffer.String()).To(ContainSubstring("  Configuring environment shared by build and launch"))
+			Expect(buffer.String()).To(ContainSubstring(fmt.Sprintf("    PATH -> \"$PATH:%s\"",
+				filepath.Join(layer.Path, "node_modules", ".bin"))))
 		})
 
 		context("when NPM_CONFIG_LOGLEVEL is set", func() {
@@ -68,12 +75,12 @@ func testEnvironment(t *testing.T, context spec.G, it spec.S) {
 				os.Unsetenv("NPM_CONFIG_LOGLEVEL")
 			})
 
-			it("configures variables using given value", func() {
+			it("does not influence the launch time env value", func() {
 				err := environment.Configure(layer)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(layer.LaunchEnv).To(Equal(packit.Environment{
-					"NPM_CONFIG_LOGLEVEL.default": "some-val",
+					"NPM_CONFIG_LOGLEVEL.default": "error",
 				}))
 			})
 		})

--- a/integration/caching_test.go
+++ b/integration/caching_test.go
@@ -137,8 +137,10 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 				fmt.Sprintf("    Running 'npm ci --unsafe-perm --cache /layers/%s/npm-cache'", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 				MatchRegexp(`      Completed in (\d+\.\d+|\d{3})`),
 				"",
-				"  Configuring environment",
+				"  Configuring launch environment",
 				"    NPM_CONFIG_LOGLEVEL -> \"error\"",
+				"",
+				"  Configuring environment shared by build and launch",
 				fmt.Sprintf("    PATH -> \"$PATH:/layers/%s/modules/node_modules/.bin\"", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 				"",
 			))

--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -77,8 +77,10 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				fmt.Sprintf("    Running 'npm install --unsafe-perm --cache /layers/%s/npm-cache'", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 				MatchRegexp(`      Completed in (\d+\.\d+|\d{3})`),
 				"",
-				"  Configuring environment",
+				"  Configuring launch environment",
 				"    NPM_CONFIG_LOGLEVEL -> \"error\"",
+				"",
+				"  Configuring environment shared by build and launch",
 				fmt.Sprintf("    PATH -> \"$PATH:/layers/%s/modules/node_modules/.bin\"", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 				"",
 			))

--- a/integration/vendored_test.go
+++ b/integration/vendored_test.go
@@ -104,8 +104,10 @@ func testVendored(t *testing.T, context spec.G, it spec.S) {
 				"    Running 'npm run-script postinstall --if-present'",
 				MatchRegexp(`      Completed in (\d+\.\d+|\d{3})`),
 				"",
-				"  Configuring environment",
+				"  Configuring launch environment",
 				"    NPM_CONFIG_LOGLEVEL -> \"error\"",
+				"",
+				"  Configuring environment shared by build and launch",
 				fmt.Sprintf("    PATH -> \"$PATH:/layers/%s/modules/node_modules/.bin\"", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 				"",
 			))


### PR DESCRIPTION
Conforms to [RFC 0019](https://github.com/paketo-buildpacks/rfcs/blob/main/accepted/0019-buildpack-set-env-vars-defaults.md) - the default behavior expected by the community.


## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have added an integration test, if necessary.
