### PR TITLE
Support service binding type 'npmrc'

### DIFF
--- a/build.go
+++ b/build.go
@@ -63,14 +63,7 @@ func Build(projectPathParser PathParser,
 		if len(bindings) == 1 {
 			logger.Process("Loading npmrc service binding")
 
-			npmrcExists := false
-			for key := range bindings[0].Entries {
-				if key == ".npmrc" {
-					npmrcExists = true
-					break
-				}
-			}
-			if !npmrcExists {
+			if _, ok := bindings[0].Entries[".npmrc"]; !ok {
 				return packit.BuildResult{}, errors.New("binding of type 'npmrc' does not contain required entry '.npmrc'")
 			}
 			globalNpmrcPath = filepath.Join(bindings[0].Path, ".npmrc")

--- a/environment.go
+++ b/environment.go
@@ -22,7 +22,7 @@ func NewEnvironment(logger scribe.Logger) Environment {
 	}
 }
 
-func (e Environment) Configure(layer packit.Layer) error {
+func (e Environment) Configure(layer packit.Layer, npmrcPath string) error {
 	for envvar, val := range e.defaultValues {
 		layer.LaunchEnv.Default(envvar, val)
 	}
@@ -36,6 +36,14 @@ func (e Environment) Configure(layer packit.Layer) error {
 	e.logger.Process("Configuring environment shared by build and launch")
 	e.logger.Subprocess("%s", scribe.NewFormattedMapFromEnvironment(layer.SharedEnv))
 	e.logger.Break()
+
+	if npmrcPath != "" {
+		layer.BuildEnv.Default("NPM_CONFIG_GLOBALCONFIG", npmrcPath)
+
+		e.logger.Process("Configuring build environment")
+		e.logger.Subprocess("%s", scribe.NewFormattedMapFromEnvironment(layer.BuildEnv))
+		e.logger.Break()
+	}
 
 	return nil
 }

--- a/fakes/binding_resolver.go
+++ b/fakes/binding_resolver.go
@@ -1,0 +1,37 @@
+package fakes
+
+import (
+	"sync"
+
+	"github.com/paketo-buildpacks/packit/v2/servicebindings"
+)
+
+type BindingResolver struct {
+	ResolveCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			Typ         string
+			Provider    string
+			PlatformDir string
+		}
+		Returns struct {
+			BindingSlice []servicebindings.Binding
+			Error        error
+		}
+		Stub func(string, string, string) ([]servicebindings.Binding, error)
+	}
+}
+
+func (f *BindingResolver) Resolve(param1 string, param2 string, param3 string) ([]servicebindings.Binding, error) {
+	f.ResolveCall.mutex.Lock()
+	defer f.ResolveCall.mutex.Unlock()
+	f.ResolveCall.CallCount++
+	f.ResolveCall.Receives.Typ = param1
+	f.ResolveCall.Receives.Provider = param2
+	f.ResolveCall.Receives.PlatformDir = param3
+	if f.ResolveCall.Stub != nil {
+		return f.ResolveCall.Stub(param1, param2, param3)
+	}
+	return f.ResolveCall.Returns.BindingSlice, f.ResolveCall.Returns.Error
+}

--- a/fakes/build_manager.go
+++ b/fakes/build_manager.go
@@ -8,7 +8,7 @@ import (
 
 type BuildManager struct {
 	ResolveCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			WorkingDir string
@@ -23,8 +23,8 @@ type BuildManager struct {
 }
 
 func (f *BuildManager) Resolve(param1 string, param2 string) (npminstall.BuildProcess, error) {
-	f.ResolveCall.Lock()
-	defer f.ResolveCall.Unlock()
+	f.ResolveCall.mutex.Lock()
+	defer f.ResolveCall.mutex.Unlock()
 	f.ResolveCall.CallCount++
 	f.ResolveCall.Receives.WorkingDir = param1
 	f.ResolveCall.Receives.CacheDir = param2

--- a/fakes/build_process.go
+++ b/fakes/build_process.go
@@ -4,25 +4,27 @@ import "sync"
 
 type BuildProcess struct {
 	RunCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			ModulesDir string
 			CacheDir   string
 			WorkingDir string
+			NpmrcPath  string
 		}
 		Returns struct {
 			Error error
 		}
-		Stub func(string, string, string) error
+		Stub func(string, string, string, string) error
 	}
 	ShouldRunCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			WorkingDir string
 			Metadata   map[string]interface {
 			}
+			NpmrcPath string
 		}
 		Returns struct {
 			Run bool
@@ -30,31 +32,33 @@ type BuildProcess struct {
 			Err error
 		}
 		Stub func(string, map[string]interface {
-		}) (bool, string, error)
+		}, string) (bool, string, error)
 	}
 }
 
-func (f *BuildProcess) Run(param1 string, param2 string, param3 string) error {
-	f.RunCall.Lock()
-	defer f.RunCall.Unlock()
+func (f *BuildProcess) Run(param1 string, param2 string, param3 string, param4 string) error {
+	f.RunCall.mutex.Lock()
+	defer f.RunCall.mutex.Unlock()
 	f.RunCall.CallCount++
 	f.RunCall.Receives.ModulesDir = param1
 	f.RunCall.Receives.CacheDir = param2
 	f.RunCall.Receives.WorkingDir = param3
+	f.RunCall.Receives.NpmrcPath = param4
 	if f.RunCall.Stub != nil {
-		return f.RunCall.Stub(param1, param2, param3)
+		return f.RunCall.Stub(param1, param2, param3, param4)
 	}
 	return f.RunCall.Returns.Error
 }
 func (f *BuildProcess) ShouldRun(param1 string, param2 map[string]interface {
-}) (bool, string, error) {
-	f.ShouldRunCall.Lock()
-	defer f.ShouldRunCall.Unlock()
+}, param3 string) (bool, string, error) {
+	f.ShouldRunCall.mutex.Lock()
+	defer f.ShouldRunCall.mutex.Unlock()
 	f.ShouldRunCall.CallCount++
 	f.ShouldRunCall.Receives.WorkingDir = param1
 	f.ShouldRunCall.Receives.Metadata = param2
+	f.ShouldRunCall.Receives.NpmrcPath = param3
 	if f.ShouldRunCall.Stub != nil {
-		return f.ShouldRunCall.Stub(param1, param2)
+		return f.ShouldRunCall.Stub(param1, param2, param3)
 	}
 	return f.ShouldRunCall.Returns.Run, f.ShouldRunCall.Returns.Sha, f.ShouldRunCall.Returns.Err
 }

--- a/fakes/environment_config.go
+++ b/fakes/environment_config.go
@@ -3,23 +3,24 @@ package fakes
 import (
 	"sync"
 
-	"github.com/paketo-buildpacks/packit/v2"
+	packit "github.com/paketo-buildpacks/packit/v2"
 )
 
 type EnvironmentConfig struct {
 	ConfigureCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
-			Layer packit.Layer
+			Layer     packit.Layer
+			NpmrcPath string
 		}
 		Returns struct {
 			Error error
 		}
-		Stub func(packit.Layer) error
+		Stub func(packit.Layer, string) error
 	}
 	GetValueCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Key string
@@ -31,19 +32,20 @@ type EnvironmentConfig struct {
 	}
 }
 
-func (f *EnvironmentConfig) Configure(param1 packit.Layer) error {
-	f.ConfigureCall.Lock()
-	defer f.ConfigureCall.Unlock()
+func (f *EnvironmentConfig) Configure(param1 packit.Layer, param2 string) error {
+	f.ConfigureCall.mutex.Lock()
+	defer f.ConfigureCall.mutex.Unlock()
 	f.ConfigureCall.CallCount++
 	f.ConfigureCall.Receives.Layer = param1
+	f.ConfigureCall.Receives.NpmrcPath = param2
 	if f.ConfigureCall.Stub != nil {
-		return f.ConfigureCall.Stub(param1)
+		return f.ConfigureCall.Stub(param1, param2)
 	}
 	return f.ConfigureCall.Returns.Error
 }
 func (f *EnvironmentConfig) GetValue(param1 string) string {
-	f.GetValueCall.Lock()
-	defer f.GetValueCall.Unlock()
+	f.GetValueCall.mutex.Lock()
+	defer f.GetValueCall.mutex.Unlock()
 	f.GetValueCall.CallCount++
 	f.GetValueCall.Receives.Key = param1
 	if f.GetValueCall.Stub != nil {

--- a/fakes/executable.go
+++ b/fakes/executable.go
@@ -8,7 +8,7 @@ import (
 
 type Executable struct {
 	ExecuteCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Execution pexec.Execution
@@ -21,8 +21,8 @@ type Executable struct {
 }
 
 func (f *Executable) Execute(param1 pexec.Execution) error {
-	f.ExecuteCall.Lock()
-	defer f.ExecuteCall.Unlock()
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.Execution = param1
 	if f.ExecuteCall.Stub != nil {

--- a/fakes/path_parser.go
+++ b/fakes/path_parser.go
@@ -4,7 +4,7 @@ import "sync"
 
 type PathParser struct {
 	GetCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Path string
@@ -18,8 +18,8 @@ type PathParser struct {
 }
 
 func (f *PathParser) Get(param1 string) (string, error) {
-	f.GetCall.Lock()
-	defer f.GetCall.Unlock()
+	f.GetCall.mutex.Lock()
+	defer f.GetCall.mutex.Unlock()
 	f.GetCall.CallCount++
 	f.GetCall.Receives.Path = param1
 	if f.GetCall.Stub != nil {

--- a/fakes/summer.go
+++ b/fakes/summer.go
@@ -4,7 +4,7 @@ import "sync"
 
 type Summer struct {
 	SumCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Paths []string
@@ -18,8 +18,8 @@ type Summer struct {
 }
 
 func (f *Summer) Sum(param1 ...string) (string, error) {
-	f.SumCall.Lock()
-	defer f.SumCall.Unlock()
+	f.SumCall.mutex.Lock()
+	defer f.SumCall.mutex.Unlock()
 	f.SumCall.CallCount++
 	f.SumCall.Receives.Paths = param1
 	if f.SumCall.Stub != nil {

--- a/fakes/version_parser.go
+++ b/fakes/version_parser.go
@@ -4,7 +4,7 @@ import "sync"
 
 type VersionParser struct {
 	ParseVersionCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Path string
@@ -18,8 +18,8 @@ type VersionParser struct {
 }
 
 func (f *VersionParser) ParseVersion(param1 string) (string, error) {
-	f.ParseVersionCall.Lock()
-	defer f.ParseVersionCall.Unlock()
+	f.ParseVersionCall.mutex.Lock()
+	defer f.ParseVersionCall.mutex.Unlock()
 	f.ParseVersionCall.CallCount++
 	f.ParseVersionCall.Receives.Path = param1
 	if f.ParseVersionCall.Stub != nil {

--- a/install_build_process_test.go
+++ b/install_build_process_test.go
@@ -63,7 +63,7 @@ func testInstallBuildProcess(t *testing.T, context spec.G, it spec.S) {
 
 	context("ShouldRun", func() {
 		it("returns true", func() {
-			run, sha, err := process.ShouldRun(workingDir, nil)
+			run, sha, err := process.ShouldRun(workingDir, nil, "some-npmrc-path")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(run).To(BeTrue())
 			Expect(sha).To(BeEmpty())
@@ -76,13 +76,13 @@ func testInstallBuildProcess(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("succeeds", func() {
-			Expect(process.Run(modulesDir, cacheDir, workingDir)).To(Succeed())
+			Expect(process.Run(modulesDir, cacheDir, workingDir, "some-npmrc-path")).To(Succeed())
 			Expect(executable.ExecuteCall.Receives.Execution).To(Equal(pexec.Execution{
 				Args:   []string{"install", "--unsafe-perm", "--cache", cacheDir},
 				Dir:    workingDir,
 				Stdout: commandOutput,
 				Stderr: commandOutput,
-				Env:    append(os.Environ(), "NPM_CONFIG_LOGLEVEL=some-val"),
+				Env:    append(os.Environ(), "NPM_CONFIG_LOGLEVEL=some-val", "NPM_CONFIG_GLOBALCONFIG=some-npmrc-path"),
 			}))
 
 			path, err := os.Readlink(filepath.Join(workingDir, "node_modules"))
@@ -97,7 +97,7 @@ func testInstallBuildProcess(t *testing.T, context spec.G, it spec.S) {
 				})
 
 				it("fails", func() {
-					err := process.Run(modulesDir, cacheDir, workingDir)
+					err := process.Run(modulesDir, cacheDir, workingDir, "")
 					Expect(err).To(MatchError(ContainSubstring("permission denied")))
 				})
 			})
@@ -113,7 +113,7 @@ func testInstallBuildProcess(t *testing.T, context spec.G, it spec.S) {
 				})
 
 				it("returns an error", func() {
-					err := process.Run(modulesDir, cacheDir, workingDir)
+					err := process.Run(modulesDir, cacheDir, workingDir, "")
 					Expect(err).To(MatchError(ContainSubstring("permission denied")))
 				})
 			})
@@ -128,7 +128,7 @@ func testInstallBuildProcess(t *testing.T, context spec.G, it spec.S) {
 				})
 
 				it("returns an error", func() {
-					err := process.Run(modulesDir, cacheDir, workingDir)
+					err := process.Run(modulesDir, cacheDir, workingDir, "")
 					Expect(buffer.String()).To(ContainSubstring("    install error on stdout\n    install error on stderr\n"))
 					Expect(err).To(MatchError("npm install failed: failed to execute"))
 				})

--- a/integration/testdata/simple_app/README.md
+++ b/integration/testdata/simple_app/README.md
@@ -1,1 +1,5 @@
 This file here to suppress "npm WARN package.json node_web_app@0.0.0 No README data"
+
+This app contains a development dependency (`spellchecker-cli`), which is only
+used to test `npmrc` service binding support. The dependency will only be installed
+if `NODE_ENV=development` or an `.npmrc` config file explicitly includes dev dependencies.

--- a/integration/testdata/simple_app/package.json
+++ b/integration/testdata/simple_app/package.json
@@ -10,6 +10,9 @@
   "dependencies": {
     "leftpad": "~0.0.1"
   },
+  "devDependencies": {
+    "spellchecker-cli": "^4.8.1"
+  },
   "repository": {
     "type": "git",
     "url": ""

--- a/run/main.go
+++ b/run/main.go
@@ -4,11 +4,13 @@ import (
 	"os"
 
 	npminstall "github.com/paketo-buildpacks/npm-install"
+
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/chronos"
 	"github.com/paketo-buildpacks/packit/v2/fs"
 	"github.com/paketo-buildpacks/packit/v2/pexec"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
+	"github.com/paketo-buildpacks/packit/v2/servicebindings"
 )
 
 func main() {
@@ -19,11 +21,13 @@ func main() {
 	checksumCalculator := fs.NewChecksumCalculator()
 	environment := npminstall.NewEnvironment(logger)
 	resolver := npminstall.NewBuildProcessResolver(executable, checksumCalculator, environment, logger)
+	bindingResolver := servicebindings.NewResolver()
 
 	packit.Run(
 		npminstall.Detect(projectPathParser, packageJSONParser),
 		npminstall.Build(
 			projectPathParser,
+			bindingResolver,
 			resolver,
 			chronos.DefaultClock,
 			environment,


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Resolves #308 

## Use Cases
<!-- An explanation of the use cases your change enables -->

We made a few decisions in this implementation that we want to call out:
1. If more than one binding of type `npmrc` is provided, the build fails, since there's no way to set `NPM_CONFIG_GLOBALCONFIG` to multiple file locations.
2. If an `npmrc` service binding is provided, `NPM_CONFIG_GLOBALCONFIG` is set to its path as a **default** environment variable on the node modules layer. As a result, if a user manually sets `NPM_CONFIG_GLOBALCONFIG` at build time, the user-provided value gets priority over the value determined by the service binding resolver.

Feedback is welcome on how these choices impact the value of the feature.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
