### PR TITLE
Use layer.ExecD to add exec.d command

### DIFF
--- a/build.go
+++ b/build.go
@@ -247,16 +247,7 @@ func Build(projectPathParser PathParser,
 					return packit.BuildResult{}, err
 				}
 
-				execdDir := filepath.Join(layer.Path, "exec.d")
-				err = os.MkdirAll(execdDir, os.ModePerm)
-				if err != nil {
-					return packit.BuildResult{}, err
-				}
-
-				err = fs.Copy(filepath.Join(context.CNBPath, "bin", "setup-symlinks"), filepath.Join(execdDir, "0-setup-symlinks"))
-				if err != nil {
-					return packit.BuildResult{}, err
-				}
+				layer.ExecD = []string{filepath.Join(context.CNBPath, "bin", "setup-symlinks")}
 			} else {
 				logger.Process("Reusing cached layer %s", layer.Path)
 				if !build {


### PR DESCRIPTION
## Summary
Use layer.ExecD to add exec.d command, using [packit 2.2.0](https://github.com/paketo-buildpacks/packit/releases/tag/v2.2.0)

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
