### PR TITLE
Make projectPath group-writable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,3 +25,4 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.45.2
+        args: --timeout 3m0s

--- a/build.go
+++ b/build.go
@@ -295,6 +295,14 @@ func Build(projectPathParser PathParser,
 			return packit.BuildResult{}, err
 		}
 
+		// Makes the projectPath group-writable to facilitate executing exec.d
+		// script at runtime under a different uid.
+		// https://github.com/paketo-buildpacks/rfcs/blob/main/text/0045-user-ids.md
+		err = os.Chmod(projectPath, 0775)
+		if err != nil {
+			return packit.BuildResult{}, err
+		}
+
 		logger.Break()
 
 		return packit.BuildResult{Layers: layers}, nil

--- a/build_test.go
+++ b/build_test.go
@@ -192,6 +192,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(processCacheDir).To(Equal(filepath.Join(layersDir, npminstall.LayerNameCache)))
 			Expect(processWorkingDir).To(Equal(workingDir))
 			Expect(processNpmrcPath).To(Equal(""))
+
+			workingDirInfo, err := os.Stat(workingDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(workingDirInfo.Mode()).To(Equal(os.FileMode(os.ModeDir | 0775)))
+
 		})
 	})
 
@@ -508,6 +513,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Expect(processLayerDir).To(Equal(filepath.Join(layersDir, "launch-modules")))
 				Expect(processCacheDir).To(Equal(filepath.Join(layersDir, npminstall.LayerNameCache)))
 				Expect(processWorkingDir).To(Equal(filepath.Join(workingDir, "some-dir")))
+
+				procWorkingDirInfo, err := os.Stat(processWorkingDir)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(procWorkingDirInfo.Mode()).To(Equal(os.FileMode(os.ModeDir | 0775)))
 			})
 		})
 


### PR DESCRIPTION

## Summary
Makes the projectPath group-writable at the end of the build phase.

## Use Cases
Resolves #355 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
