### PR TITLE
Don't fail job when chmod fails

### DIFF
--- a/build.go
+++ b/build.go
@@ -300,7 +300,7 @@ func Build(projectPathParser PathParser,
 		// https://github.com/paketo-buildpacks/rfcs/blob/main/text/0045-user-ids.md
 		err = os.Chmod(projectPath, 0775)
 		if err != nil {
-			return packit.BuildResult{}, err
+			logger.Process("WARNING: unable to chmod %s:\n%s", projectPath, err)
 		}
 
 		logger.Break()

--- a/build_test.go
+++ b/build_test.go
@@ -198,6 +198,32 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(workingDirInfo.Mode()).To(Equal(os.FileMode(os.ModeDir | 0775)))
 
 		})
+		it("doesn't fail when chmod fails ", func() {
+			if _, err := os.Stat("/dev/null"); errors.Is(err, os.ErrNotExist) {
+				t.Skip("No /dev/null thus not a unix system. Skipping chmod test.")
+			}
+
+			Expect(os.RemoveAll(workingDir)).To(Succeed())
+			Expect(os.Symlink("/dev/null", workingDir)).To(Succeed())
+
+			_, err := build(packit.BuildContext{
+				BuildpackInfo: packit.BuildpackInfo{
+					SBOMFormats: []string{"application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"},
+				},
+				Platform: packit.Platform{
+					Path: "some-platform-path",
+				},
+				WorkingDir: workingDir,
+				CNBPath:    cnbDir,
+				Layers:     packit.Layers{Path: layersDir},
+				Plan: packit.BuildpackPlan{
+					Entries: []packit.BuildpackPlanEntry{
+						{Name: "node_modules"},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 
 	context("when required during launch", func() {
@@ -517,6 +543,29 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				procWorkingDirInfo, err := os.Stat(processWorkingDir)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(procWorkingDirInfo.Mode()).To(Equal(os.FileMode(os.ModeDir | 0775)))
+			})
+			it("doesn't fail when chmod fails ", func() {
+				if _, err := os.Stat("/dev/null"); errors.Is(err, os.ErrNotExist) {
+					t.Skip("No /dev/null thus not a unix system. Skipping chmod test.")
+				}
+
+				Expect(os.RemoveAll(workingDir)).To(Succeed())
+				Expect(os.Symlink("/dev/null", workingDir)).To(Succeed())
+
+				_, err := build(packit.BuildContext{
+					BuildpackInfo: packit.BuildpackInfo{
+						SBOMFormats: []string{"application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"},
+					},
+					WorkingDir: workingDir,
+					Layers:     packit.Layers{Path: layersDir},
+					CNBPath:    cnbDir,
+					Plan: packit.BuildpackPlan{
+						Entries: []packit.BuildpackPlanEntry{
+							{Name: "node_modules"},
+						},
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 


### PR DESCRIPTION
## Summary
Fixes #371 

## Use Cases
When buildpacks are runned in user-space, i.e. with non-root user, we cannot `chmod` directories. This will be OK for the build.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
