### PR TITLE
Create intermediate symlink for switching between build and launch modules

### DIFF
--- a/cmd/setup-symlinks/internal/run.go
+++ b/cmd/setup-symlinks/internal/run.go
@@ -7,19 +7,14 @@ import (
 	"strings"
 )
 
-func Run(executablePath, appDir string) error {
+func Run(executablePath, appDir, tmpDir string) error {
 	fname := strings.Split(executablePath, "/")
 	layerPath := filepath.Join(fname[:len(fname)-2]...)
 	if filepath.IsAbs(executablePath) {
 		layerPath = fmt.Sprintf("/%s", layerPath)
 	}
 
-	err := os.RemoveAll(filepath.Join(appDir, "node_modules"))
-	if err != nil {
-		return err
-	}
-
-	err = os.Symlink(filepath.Join(layerPath, "node_modules"), filepath.Join(appDir, "node_modules"))
+	err := os.Symlink(filepath.Join(layerPath, "node_modules"), filepath.Join(tmpDir, "node_modules"))
 	if err != nil {
 		return err
 	}

--- a/cmd/setup-symlinks/internal/run_test.go
+++ b/cmd/setup-symlinks/internal/run_test.go
@@ -25,6 +25,7 @@ func testRun(t *testing.T, context spec.G, it spec.S) {
 		layerDir       string
 		executablePath string
 		appDir         string
+		tmpDir         string
 	)
 
 	it.Before(func() {
@@ -35,6 +36,9 @@ func testRun(t *testing.T, context spec.G, it spec.S) {
 		appDir, err = os.MkdirTemp("", "appDir")
 		Expect(err).NotTo(HaveOccurred())
 
+		tmpDir, err = os.MkdirTemp("", "tmp")
+		Expect(err).NotTo(HaveOccurred())
+
 		Expect(os.MkdirAll(filepath.Join(layerDir, "node_modules"), os.ModePerm)).To(Succeed())
 
 		executablePath = filepath.Join(layerDir, "execd", "0-setup-symlinks")
@@ -42,8 +46,6 @@ func testRun(t *testing.T, context spec.G, it spec.S) {
 
 		err = os.WriteFile(executablePath, []byte(""), 0600)
 		Expect(err).NotTo(HaveOccurred())
-
-		Expect(os.Symlink("build-modules", filepath.Join(appDir, "node_modules"))).To(Succeed())
 
 	})
 
@@ -53,24 +55,24 @@ func testRun(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("creates a symlink to the node_modules dir in the layer", func() {
-		err := internal.Run(executablePath, appDir)
+		err := internal.Run(executablePath, appDir, tmpDir)
 		Expect(err).NotTo(HaveOccurred())
 
-		link, err := os.Readlink(filepath.Join(appDir, "node_modules"))
+		link, err := os.Readlink(filepath.Join(tmpDir, "node_modules"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(link).To(Equal(filepath.Join(layerDir, "node_modules")))
 	})
 
 	context("failure cases", func() {
-		context("when the app dir node_modules cannot be removed", func() {
+		context("when the tmp dir node_modules cannot be removed", func() {
 			it.Before(func() {
-				Expect(os.Chmod(appDir, 0444)).To(Succeed())
+				Expect(os.Chmod(tmpDir, 0444)).To(Succeed())
 			})
 			it.After(func() {
-				Expect(os.Chmod(appDir, os.ModePerm)).To(Succeed())
+				Expect(os.Chmod(tmpDir, os.ModePerm)).To(Succeed())
 			})
 			it("returns an error", func() {
-				err := internal.Run(executablePath, appDir)
+				err := internal.Run(executablePath, appDir, tmpDir)
 				Expect(err).To(MatchError(ContainSubstring("permission denied")))
 			})
 		})

--- a/cmd/setup-symlinks/main.go
+++ b/cmd/setup-symlinks/main.go
@@ -13,7 +13,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = internal.Run(os.Args[0], wd)
+	err = internal.Run(os.Args[0], wd, "/tmp")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/run/main.go
+++ b/run/main.go
@@ -31,6 +31,7 @@ func main() {
 	entryResolver := draft.NewPlanner()
 	sbomGenerator := SBOMGenerator{}
 	packageManagerConfigurationManager := npminstall.NewPackageManagerConfigurationManager(servicebindings.NewResolver(), logger)
+	tmpDir := "/tmp"
 
 	packit.Run(
 		npminstall.Detect(
@@ -45,6 +46,8 @@ func main() {
 			pruneBuildProcess,
 			chronos.DefaultClock,
 			logger,
-			sbomGenerator),
+			sbomGenerator,
+			tmpDir,
+		),
 	)
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Avoids changing `/workspace` permissions, creating instead a symlink in `/tmp` which points to build modules during build and launch modules at launch. The `/tmp` symlink is pointed to by the `node_modules` symlink in `/workspace` (i.e. `/workspace/node_modules` -> `/tmp/node_modules` -> `{build, launch}-modules` layer).

The `exec.d` script is now only run when `node_modules` is required for both build and launch.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This should resolve https://github.com/paketo-buildpacks/nodejs/issues/602, while still conforming to the Secure Runtime RFC requirements. 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
