### PR TITLE
Use os.TempDir() instead of hardcoded temp folder path

### DIFF
--- a/cmd/setup-symlinks/main.go
+++ b/cmd/setup-symlinks/main.go
@@ -13,7 +13,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = internal.Run(os.Args[0], wd, "/tmp")
+	err = internal.Run(os.Args[0], wd, os.TempDir())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/run/main.go
+++ b/run/main.go
@@ -31,7 +31,7 @@ func main() {
 	entryResolver := draft.NewPlanner()
 	sbomGenerator := SBOMGenerator{}
 	packageManagerConfigurationManager := npminstall.NewPackageManagerConfigurationManager(servicebindings.NewResolver(), logger)
-	tmpDir := "/tmp"
+	tmpDir := os.TempDir()
 
 	packit.Run(
 		npminstall.Detect(


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Instead of using hardcoded `/tmp` path, `os.TempDir()` should be used, which respects `$TMPDIR` environment variable, or returns os-specific temp folder path by default.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Platform might not have a `/tmp` folder present or it might provide a `$TMPDIR` with the valid temp dir path

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
