### PR TITLE
When creating symlinks, do not rely on TMPDIR being the same on build and on run

### DIFF
--- a/cmd/setup-symlinks/internal/run.go
+++ b/cmd/setup-symlinks/internal/run.go
@@ -7,22 +7,36 @@ import (
 	"strings"
 )
 
-func Run(executablePath, appDir, tmpDir string) error {
+func Run(executablePath, appDir string) error {
 	fname := strings.Split(executablePath, "/")
 	layerPath := filepath.Join(fname[:len(fname)-2]...)
 	if filepath.IsAbs(executablePath) {
 		layerPath = fmt.Sprintf("/%s", layerPath)
 	}
 
-	err := os.RemoveAll(filepath.Join(tmpDir, "node_modules"))
+	linkPath, err := os.Readlink(filepath.Join(appDir, "node_modules"))
 	if err != nil {
 		return err
 	}
 
-	err = os.Symlink(filepath.Join(layerPath, "node_modules"), filepath.Join(tmpDir, "node_modules"))
+	linkPath, err = filepath.Abs(linkPath)
 	if err != nil {
 		return err
 	}
 
-	return nil
+	return createSymlink(filepath.Join(layerPath, "node_modules"), linkPath)
+}
+
+func createSymlink(target, source string) error {
+	err := os.RemoveAll(source)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(filepath.Dir(source), os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	return os.Symlink(target, source)
 }

--- a/cmd/setup-symlinks/main.go
+++ b/cmd/setup-symlinks/main.go
@@ -13,7 +13,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = internal.Run(os.Args[0], wd, os.TempDir())
+	err = internal.Run(os.Args[0], wd)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
If the platform sets TMP to a randomly created tempdir, the symlink from the workspace was broken.

## Use Cases
<!-- An explanation of the use cases your change enables -->
TMPDIR might be different when building and when running the image.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
