### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Paketo Buildpack for NPM Install Cloud Native
+# Paketo Buildpack for NPM Install
 
 The NPM Install CNB makes use of the [`npm`](https://www.npmjs.com/) tooling
 installed within the [Node Engine CNB](https://github.com/paketo-buildpacks/node-engine)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Paketo NPM Install Cloud Native Buildpack
+# Paketo Buildpack for NPM Install Cloud Native
 
 The NPM Install CNB makes use of the [`npm`](https://www.npmjs.com/) tooling
 installed within the [Node Engine CNB](https://github.com/paketo-buildpacks/node-engine)

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.7"
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/npm-install"
   id = "paketo-buildpacks/npm-install"
-  name = "Paketo NPM Install Buildpack"
+  name = "Paketo Buildpack for NPM Install"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo NPM Install Buildpack' to 'Paketo Buildpack for NPM Install'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
