### PR TITLE
Ignore removed workspace folders in setup-symlinks helper

### DIFF
--- a/cmd/setup-symlinks/internal/run.go
+++ b/cmd/setup-symlinks/internal/run.go
@@ -46,22 +46,23 @@ func Run(executablePath, appDir string, symlinkResolver npminstall.SymlinkResolv
 }
 
 func resolveWorkspaceModules(symlinkResolver npminstall.SymlinkResolver, appDir, layerPath string) error {
-
 	lockFile, err := symlinkResolver.ParseLockfile(filepath.Join(appDir, "package-lock.json"))
 	if err != nil {
 		return err
 	}
 
-	dir := filepath.Dir(filepath.Join(appDir, "package-lock.json"))
 	for _, pkg := range lockFile.Packages {
 		if pkg.Link {
-
-			linkPath, err := os.Readlink(filepath.Join(dir, pkg.Resolved))
+			linkPath, err := os.Readlink(filepath.Join(appDir, pkg.Resolved))
 			if err != nil {
-				return err
+				if errors.Is(err, fs.ErrNotExist) {
+					continue
+				} else {
+					return err
+				}
 			}
 
-			err = createSymlink(filepath.Join(layerPath, pkg.Resolved), filepath.Join(linkPath, pkg.Resolved))
+			err = createSymlink(filepath.Join(layerPath, pkg.Resolved), linkPath)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
It contains 2 fixes:
* The symlinks for workspaces created by `setup-symlink` had an invalid target.
* If a workspace does not exist, the helper failed because the symlink could not be read.

## Use Cases
<!-- An explanation of the use cases your change enables -->
In case you do not want your final image to contain a workspace and delete it after build, the helper `setup-symlinks` would fail. Now, instead of failing, this symlink is just not created.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
