### PR TITLE
Fix flaky unit test: linked_module_resolver_test

### DIFF
--- a/linked_module_resolver_test.go
+++ b/linked_module_resolver_test.go
@@ -131,7 +131,17 @@ func testLinkedModuleResolver(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the destination cannot be scaffolded", func() {
 				it.Before(func() {
-					Expect(os.WriteFile(filepath.Join(layerPath, "sub-dir"), nil, 0400)).To(Succeed())
+					err := os.WriteFile(filepath.Join(workspace, "package-lock.json"), []byte(`{
+						"packages": {
+							"module": {
+								"resolved": "src/packages/module",
+								"link": true
+							}
+						}
+					}`), 0600)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(os.Mkdir(filepath.Join(layerPath, "sub-dir"), 0400)).To(Succeed())
 				})
 
 				it("returns an error", func() {
@@ -209,7 +219,17 @@ func testLinkedModuleResolver(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the destination cannot be scaffolded", func() {
 				it.Before(func() {
-					Expect(os.WriteFile(filepath.Join(otherLayerPath, "sub-dir"), nil, 0400)).To(Succeed())
+					err := os.WriteFile(filepath.Join(workspace, "package-lock.json"), []byte(`{
+						"packages": {
+							"module": {
+								"resolved": "src/packages/module",
+								"link": true
+							}
+						}
+					}`), 0600)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(os.Mkdir(filepath.Join(otherLayerPath, "sub-dir"), 0400)).To(Succeed())
 				})
 
 				it("returns an error", func() {

--- a/linked_module_resolver_test.go
+++ b/linked_module_resolver_test.go
@@ -131,7 +131,7 @@ func testLinkedModuleResolver(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the destination cannot be scaffolded", func() {
 				it.Before(func() {
-					Expect(os.Mkdir(filepath.Join(layerPath, "sub-dir"), 0400)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(layerPath, "sub-dir"), nil, 0400)).To(Succeed())
 				})
 
 				it("returns an error", func() {
@@ -209,7 +209,7 @@ func testLinkedModuleResolver(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the destination cannot be scaffolded", func() {
 				it.Before(func() {
-					Expect(os.Mkdir(filepath.Join(otherLayerPath, "sub-dir"), 0400)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(otherLayerPath, "sub-dir"), nil, 0400)).To(Succeed())
 				})
 
 				it("returns an error", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The unit test `linked_module_resolver_test` was flaky.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
