### PR TITLE
Request cpython if there is a node-gyp dependency

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -4,6 +4,7 @@ const (
 	NodeModules = "node_modules"
 	Node        = "node"
 	Npm         = "npm"
+	Cpython     = "cpython"
 
 	LayerNameNodeModules = "modules"
 	LayerNameCache       = "npm-cache"

--- a/detect.go
+++ b/detect.go
@@ -39,6 +39,10 @@ func Detect() packit.DetectFunc {
 		}
 		version := pkg.GetVersion()
 
+		_, nodeGypInDep := pkg.Dependencies["node-gyp"]
+		_, nodeGypInDevDep := pkg.DevDependencies["node-gyp"]
+		pythonNeeded := nodeGypInDep || nodeGypInDevDep
+
 		nodeDependency := packit.BuildPlanRequirement{
 			Name: Node,
 			Metadata: BuildPlanMetadata{
@@ -54,21 +58,36 @@ func Detect() packit.DetectFunc {
 			}
 		}
 
-		return packit.DetectResult{
+		npmDependency := packit.BuildPlanRequirement{
+			Name: Npm,
+			Metadata: BuildPlanMetadata{
+				Build: true,
+			},
+		}
+
+		cPythonDependency := packit.BuildPlanRequirement{
+			Name: Cpython,
+			Metadata: BuildPlanMetadata{
+				Build: true,
+			},
+		}
+
+		result := packit.DetectResult{
 			Plan: packit.BuildPlan{
 				Provides: []packit.BuildPlanProvision{
 					{Name: NodeModules},
 				},
 				Requires: []packit.BuildPlanRequirement{
 					nodeDependency,
-					{
-						Name: Npm,
-						Metadata: BuildPlanMetadata{
-							Build: true,
-						},
-					},
+					npmDependency,
 				},
 			},
-		}, nil
+		}
+
+		if pythonNeeded {
+			result.Plan.Requires = append(result.Plan.Requires, cPythonDependency)
+		}
+
+		return result, nil
 	}
 }

--- a/detect_test.go
+++ b/detect_test.go
@@ -63,6 +63,47 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		}))
 
 	})
+	context("when the package.json declares a node-gyp dependency", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filePath, []byte(`{
+				"dependencies": {
+						"node-gyp": "1.2.3"
+				}
+			}`), 0600)).To(Succeed())
+		})
+
+		it("returns a plan requesting cpython", func() {
+			result, err := detect(packit.DetectContext{
+				WorkingDir: workingDir,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Plan).To(Equal(packit.BuildPlan{
+				Provides: []packit.BuildPlanProvision{
+					{Name: npminstall.NodeModules},
+				},
+				Requires: []packit.BuildPlanRequirement{
+					{
+						Name: npminstall.Node,
+						Metadata: npminstall.BuildPlanMetadata{
+							Build: true,
+						},
+					},
+					{
+						Name: npminstall.Npm,
+						Metadata: npminstall.BuildPlanMetadata{
+							Build: true,
+						},
+					},
+					{
+						Name: npminstall.Cpython,
+						Metadata: npminstall.BuildPlanMetadata{
+							Build: true,
+						},
+					},
+				},
+			}))
+		})
+	})
 
 	context("when the package.json does not declare a node engine version", func() {
 		it.Before(func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
see https://github.com/paketo-buildpacks/nodejs/issues/691

prerequisites:
* `libnodejs` returns not only the scripts from `package.json`, but all dependencies so that they can be checked: https://github.com/paketo-buildpacks/libnodejs/pull/33

## Summary
If a dependency to `node-gyp` is found, `cpython` is requested to provide `python for the build.

## Use Cases
For `nodejs` app containing a dependency to `node-gyp`, the full stack was required since it is currently the only one containing python needed for the build.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
