### PR TITLE
Using regex to match syft SBOM version

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	npminstall "github.com/paketo-buildpacks/npm-install"
@@ -240,7 +241,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			content, err = io.ReadAll(syft.Content)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(MatchJSON(`{
+			versionPattern := regexp.MustCompile(`\d+\.\d+\.\d+`)
+			contentReplaced := versionPattern.ReplaceAllString(string(content), `x.x.x`)
+			Expect(contentReplaced).To(MatchJSON(`{
 				"artifacts": [],
 				"artifactRelationships": [],
 				"source": {
@@ -256,8 +259,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"version": ""
 				},
 				"schema": {
-					"version": "16.0.36",
-					"url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-16.0.36.json"
+					"version": "x.x.x",
+					"url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-x.x.x.json"
 				}
 			}`))
 
@@ -404,7 +407,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			content, err = io.ReadAll(syft.Content)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(MatchJSON(`{
+			versionPattern := regexp.MustCompile(`\d+\.\d+\.\d+`)
+			contentReplaced := versionPattern.ReplaceAllString(string(content), `x.x.x`)
+			Expect(contentReplaced).To(MatchJSON(`{
 				"artifacts": [],
 				"artifactRelationships": [],
 				"source": {
@@ -420,8 +425,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"version": ""
 				},
 				"schema": {
-					"version": "16.0.36",
-					"url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-16.0.36.json"
+					"version": "x.x.x",
+					"url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-x.x.x.json"
 				}
 			}`))
 
@@ -605,7 +610,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			content, err = io.ReadAll(syft.Content)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(MatchJSON(`{
+			versionPattern := regexp.MustCompile(`\d+\.\d+\.\d+`)
+			contentReplaced := versionPattern.ReplaceAllString(string(content), `x.x.x`)
+			Expect(contentReplaced).To(MatchJSON(`{
 				"artifacts": [],
 				"artifactRelationships": [],
 				"source": {
@@ -621,8 +628,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"version": ""
 				},
 				"schema": {
-					"version": "16.0.36",
-					"url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-16.0.36.json"
+					"version": "x.x.x",
+					"url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-x.x.x.json"
 				}
 			}`))
 
@@ -716,7 +723,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			content, err = io.ReadAll(syft.Content)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(MatchJSON(`{
+			versionPattern = regexp.MustCompile(`\d+\.\d+\.\d+`)
+			contentReplaced = versionPattern.ReplaceAllString(string(content), `x.x.x`)
+			Expect(contentReplaced).To(MatchJSON(`{
 				"artifacts": [],
 				"artifactRelationships": [],
 				"source": {
@@ -732,8 +741,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"version": ""
 				},
 				"schema": {
-					"version": "16.0.36",
-					"url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-16.0.36.json"
+					"version": "x.x.x",
+					"url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-x.x.x.json"
 				}
 			}`))
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* uses regex to match SBOM version on unit tests, avoiding that way errors on the unit tests each time the syft library changes version.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
