### PR TITLE
Altering unit tests to match versions and uuids based on a regex

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -51,6 +51,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		build packit.BuildFunc
 	)
 
+	var versionRegex = regexp.MustCompile(`\d+\.\d+\.\d+`)
+	var licenseListVersionRegex = regexp.MustCompile(`"licenseListVersion": "\d+\.\d+"`)
+	var uuidRegex = regexp.MustCompile(`[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}`)
+
 	it.Before(func() {
 		var err error
 		layersDir, err = os.MkdirTemp("", "layers")
@@ -203,8 +207,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}`))
 
 			content, err = io.ReadAll(spdx.Content)
+			contentReplaced := licenseListVersionRegex.ReplaceAllString(string(content), `"licenseListVersion": "x.x"`)
+			contentReplaced = uuidRegex.ReplaceAllString(contentReplaced, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(MatchJSON(`{
+			Expect(string(contentReplaced)).To(MatchJSON(`{
 				"SPDXID": "SPDXRef-DOCUMENT",
 				"creationInfo": {
 					"created": "0001-01-01T00:00:00Z",
@@ -212,10 +218,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						"Organization: Anchore, Inc",
 						"Tool: -"
 					],
-					"licenseListVersion": "3.25"
+					"licenseListVersion": "x.x"
 				},
 				"dataLicense": "CC0-1.0",
-				"documentNamespace": "https://paketo.io/unknown-source-type/unknown-9ecf240a-d971-5a3c-8e7b-6d3f3ea4d9c2",
+				"documentNamespace": "https://paketo.io/unknown-source-type/unknown-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				"name": "unknown",
 				"packages": [
 					{
@@ -241,8 +247,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			content, err = io.ReadAll(syft.Content)
 			Expect(err).NotTo(HaveOccurred())
-			versionPattern := regexp.MustCompile(`\d+\.\d+\.\d+`)
-			contentReplaced := versionPattern.ReplaceAllString(string(content), `x.x.x`)
+			contentReplaced = versionRegex.ReplaceAllString(string(content), `x.x.x`)
 			Expect(contentReplaced).To(MatchJSON(`{
 				"artifacts": [],
 				"artifactRelationships": [],
@@ -370,7 +375,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			content, err = io.ReadAll(spdx.Content)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(MatchJSON(`{
+			contentReplaced := licenseListVersionRegex.ReplaceAllString(string(content), `"licenseListVersion": "x.x"`)
+			contentReplaced = uuidRegex.ReplaceAllString(contentReplaced, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+			Expect(string(contentReplaced)).To(MatchJSON(`{
 				"SPDXID": "SPDXRef-DOCUMENT",
 				"creationInfo": {
 					"created": "0001-01-01T00:00:00Z",
@@ -378,10 +385,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						"Organization: Anchore, Inc",
 						"Tool: -"
 					],
-					"licenseListVersion": "3.25"
+					"licenseListVersion": "x.x"
 				},
 				"dataLicense": "CC0-1.0",
-				"documentNamespace": "https://paketo.io/unknown-source-type/unknown-9ecf240a-d971-5a3c-8e7b-6d3f3ea4d9c2",
+				"documentNamespace": "https://paketo.io/unknown-source-type/unknown-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				"name": "unknown",
 				"packages": [
 					{
@@ -407,8 +414,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			content, err = io.ReadAll(syft.Content)
 			Expect(err).NotTo(HaveOccurred())
-			versionPattern := regexp.MustCompile(`\d+\.\d+\.\d+`)
-			contentReplaced := versionPattern.ReplaceAllString(string(content), `x.x.x`)
+			contentReplaced = versionRegex.ReplaceAllString(string(content), `x.x.x`)
 			Expect(contentReplaced).To(MatchJSON(`{
 				"artifacts": [],
 				"artifactRelationships": [],
@@ -573,7 +579,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			content, err = io.ReadAll(spdx.Content)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(MatchJSON(`{
+			contentReplaced := licenseListVersionRegex.ReplaceAllString(string(content), `"licenseListVersion": "x.x"`)
+			contentReplaced = uuidRegex.ReplaceAllString(contentReplaced, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+			Expect(string(contentReplaced)).To(MatchJSON(`{
 				"SPDXID": "SPDXRef-DOCUMENT",
 				"creationInfo": {
 					"created": "0001-01-01T00:00:00Z",
@@ -581,10 +589,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						"Organization: Anchore, Inc",
 						"Tool: -"
 					],
-					"licenseListVersion": "3.25"
+					"licenseListVersion": "x.x"
 				},
 				"dataLicense": "CC0-1.0",
-				"documentNamespace": "https://paketo.io/unknown-source-type/unknown-9ecf240a-d971-5a3c-8e7b-6d3f3ea4d9c2",
+				"documentNamespace": "https://paketo.io/unknown-source-type/unknown-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				"name": "unknown",
 				"packages": [
 					{
@@ -610,8 +618,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			content, err = io.ReadAll(syft.Content)
 			Expect(err).NotTo(HaveOccurred())
-			versionPattern := regexp.MustCompile(`\d+\.\d+\.\d+`)
-			contentReplaced := versionPattern.ReplaceAllString(string(content), `x.x.x`)
+			contentReplaced = versionRegex.ReplaceAllString(string(content), `x.x.x`)
 			Expect(contentReplaced).To(MatchJSON(`{
 				"artifacts": [],
 				"artifactRelationships": [],
@@ -686,7 +693,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			content, err = io.ReadAll(spdx.Content)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(MatchJSON(`{
+			contentReplaced = licenseListVersionRegex.ReplaceAllString(string(content), `"licenseListVersion": "x.x"`)
+			contentReplaced = uuidRegex.ReplaceAllString(contentReplaced, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+			Expect(string(contentReplaced)).To(MatchJSON(`{
 				"SPDXID": "SPDXRef-DOCUMENT",
 				"creationInfo": {
 					"created": "0001-01-01T00:00:00Z",
@@ -694,10 +703,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						"Organization: Anchore, Inc",
 						"Tool: -"
 					],
-					"licenseListVersion": "3.25"
+					"licenseListVersion": "x.x"
 				},
 				"dataLicense": "CC0-1.0",
-				"documentNamespace": "https://paketo.io/unknown-source-type/unknown-9ecf240a-d971-5a3c-8e7b-6d3f3ea4d9c2",
+				"documentNamespace": "https://paketo.io/unknown-source-type/unknown-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				"name": "unknown",
 				"packages": [
 					{
@@ -723,8 +732,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			content, err = io.ReadAll(syft.Content)
 			Expect(err).NotTo(HaveOccurred())
-			versionPattern = regexp.MustCompile(`\d+\.\d+\.\d+`)
-			contentReplaced = versionPattern.ReplaceAllString(string(content), `x.x.x`)
+			contentReplaced = versionRegex.ReplaceAllString(string(content), `x.x.x`)
 			Expect(contentReplaced).To(MatchJSON(`{
 				"artifacts": [],
 				"artifactRelationships": [],


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR replaces the hardcoded uuids and version numbers on unit tests, based on a regular expression. This helps to unblock future unit tests that increment the version numbers or use different uuids on their json output, each time a package does an upgrades. As a result this PR will allow to merge this PR https://github.com/paketo-buildpacks/npm-install/pull/988 and future similar PRs.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
