### PR TITLE
Link packages from package-lock.json when rebuilding

### DIFF
--- a/build.go
+++ b/build.go
@@ -54,6 +54,7 @@ type Symlinker interface {
 
 //go:generate faux --interface SymlinkResolver --output fakes/symlink_resolver.go
 type SymlinkResolver interface {
+	WithoutCopying() SymlinkResolver
 	ParseLockfile(lockfilePath string) (Lockfile, error)
 	Copy(lockfilePath, sourceLayerPath, targetLayerPath string) error
 	Resolve(lockfilePath, layerPath string) error
@@ -357,6 +358,11 @@ func Build(entryResolver EntryResolver,
 				logger.Process("Reusing cached layer %s", layer.Path)
 				if !build {
 					err = linker.Link(filepath.Join(projectPath, "node_modules"), filepath.Join(layer.Path, "node_modules"))
+					if err != nil {
+						return packit.BuildResult{}, err
+					}
+
+					err = symlinkResolver.WithoutCopying().Resolve(filepath.Join(projectPath, "package-lock.json"), layer.Path)
 					if err != nil {
 						return packit.BuildResult{}, err
 					}

--- a/build_test.go
+++ b/build_test.go
@@ -844,6 +844,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when the build process should not run", func() {
 		it.Before(func() {
+			symlinkResolver.WithoutCopyingCall.Returns.SymlinkResolver = symlinkResolver
 			buildProcess.ShouldRunCall.Returns.Run = false
 			entryResolver.MergeLayerTypesCall.Returns.Launch = true
 			Expect(os.MkdirAll(filepath.Join(workingDir, "node_modules"), os.ModePerm))

--- a/fakes/symlink_resolver.go
+++ b/fakes/symlink_resolver.go
@@ -44,6 +44,14 @@ type SymlinkResolver struct {
 		}
 		Stub func(string, string) error
 	}
+	WithoutCopyingCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Returns   struct {
+			SymlinkResolver npminstall.SymlinkResolver
+		}
+		Stub func() npminstall.SymlinkResolver
+	}
 }
 
 func (f *SymlinkResolver) Copy(param1 string, param2 string, param3 string) error {
@@ -78,4 +86,13 @@ func (f *SymlinkResolver) Resolve(param1 string, param2 string) error {
 		return f.ResolveCall.Stub(param1, param2)
 	}
 	return f.ResolveCall.Returns.Error
+}
+func (f *SymlinkResolver) WithoutCopying() npminstall.SymlinkResolver {
+	f.WithoutCopyingCall.mutex.Lock()
+	defer f.WithoutCopyingCall.mutex.Unlock()
+	f.WithoutCopyingCall.CallCount++
+	if f.WithoutCopyingCall.Stub != nil {
+		return f.WithoutCopyingCall.Stub()
+	}
+	return f.WithoutCopyingCall.Returns.SymlinkResolver
 }

--- a/integration/caching_test.go
+++ b/integration/caching_test.go
@@ -452,58 +452,62 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	context("when the app has workspaces", func() {
-		it("ensures the workspaces are linked correctly", func() {
-			var err error
-			source, err = occam.Source(filepath.Join("testdata", "workspaces", "commonjs"))
-			Expect(err).NotTo(HaveOccurred())
+		tc := func(name string) func() {
+			return func() {
+				var err error
+				source, err = occam.Source(filepath.Join("testdata", "workspaces", name))
+				Expect(err).NotTo(HaveOccurred())
 
-			build := pack.Build.
-				WithPullPolicy(pullPolicy).
-				WithExtensions(
-					settings.Extensions.UbiNodejsExtension.Online,
-				).
-				WithBuildpacks(
-					settings.Buildpacks.NodeEngine.Online,
-					settings.Buildpacks.NPMInstall.Online,
-					settings.Buildpacks.BuildPlan.Online,
-				)
+				build := pack.Build.
+					WithPullPolicy(pullPolicy).
+					WithExtensions(
+						settings.Extensions.UbiNodejsExtension.Online,
+					).
+					WithBuildpacks(
+						settings.Buildpacks.NodeEngine.Online,
+						settings.Buildpacks.NPMInstall.Online,
+						settings.Buildpacks.BuildPlan.Online,
+					)
 
-			firstImage, logs, err := build.Execute(name, source)
-			Expect(err).NotTo(HaveOccurred(), logs.String)
+				firstImage, logs, err := build.Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String)
 
-			imageIDs[firstImage.ID] = struct{}{}
+				imageIDs[firstImage.ID] = struct{}{}
 
-			Expect(firstImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
+				Expect(firstImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
 
-			container, err := docker.Container.Run.
-				WithCommand("node server.js").
-				WithEnv(map[string]string{"PORT": "8080"}).
-				WithPublish("8080").
-				Execute(firstImage.ID)
-			Expect(err).NotTo(HaveOccurred())
+				container, err := docker.Container.Run.
+					WithCommand("node server.js").
+					WithEnv(map[string]string{"PORT": "8080"}).
+					WithPublish("8080").
+					Execute(firstImage.ID)
+				Expect(err).NotTo(HaveOccurred())
 
-			containerIDs[container.ID] = struct{}{}
+				containerIDs[container.ID] = struct{}{}
 
-			Eventually(container).Should(BeAvailable())
+				Eventually(container).Should(BeAvailable())
 
-			secondImage, logs, err := build.Execute(name, source)
-			Expect(err).NotTo(HaveOccurred(), logs.String)
+				secondImage, logs, err := build.Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String)
 
-			imageIDs[secondImage.ID] = struct{}{}
+				imageIDs[secondImage.ID] = struct{}{}
 
-			Expect(secondImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
+				Expect(secondImage.Buildpacks[1].Key).To(Equal(settings.Buildpack.ID))
 
-			container, err = docker.Container.Run.
-				WithCommand("node server.js").
-				WithEnv(map[string]string{"PORT": "8080"}).
-				WithPublish("8080").
-				Execute(secondImage.ID)
-			Expect(err).NotTo(HaveOccurred())
+				container, err = docker.Container.Run.
+					WithCommand("node server.js").
+					WithEnv(map[string]string{"PORT": "8080"}).
+					WithPublish("8080").
+					Execute(secondImage.ID)
+				Expect(err).NotTo(HaveOccurred())
 
-			containerIDs[container.ID] = struct{}{}
+				containerIDs[container.ID] = struct{}{}
 
-			Eventually(container).Should(BeAvailable())
-			Expect(secondImage.ID).To(Equal(firstImage.ID))
-		})
+				Eventually(container).Should(BeAvailable())
+				Expect(secondImage.ID).To(Equal(firstImage.ID))
+			}
+		}
+		it("ensures the commonjs workspaces are linked correctly", tc("commonjs"))
+		it("ensures the ecmascript workspaces are linked correctly", tc("ecmascript"))
 	})
 }

--- a/linked_module_resolver.go
+++ b/linked_module_resolver.go
@@ -17,13 +17,19 @@ type Lockfile struct {
 }
 
 type LinkedModuleResolver struct {
-	linker Symlinker
+	linker   Symlinker
+	linkOnly bool
 }
 
 func NewLinkedModuleResolver(linker Symlinker) LinkedModuleResolver {
 	return LinkedModuleResolver{
 		linker: linker,
 	}
+}
+
+func (r LinkedModuleResolver) WithoutCopying() SymlinkResolver {
+	r.linkOnly = true
+	return r
 }
 
 func (r LinkedModuleResolver) ParseLockfile(lockfilePath string) (lockfile Lockfile, err error) {
@@ -90,14 +96,16 @@ func (r LinkedModuleResolver) Resolve(lockfilePath, layerPath string) error {
 			source := filepath.Join(dir, pkg.Resolved)
 			destination := filepath.Join(layerPath, pkg.Resolved)
 
-			err = os.MkdirAll(filepath.Dir(destination), os.ModePerm)
-			if err != nil {
-				return fmt.Errorf("failed to setup linked module directory scaffolding: %w", err)
-			}
+			if !r.linkOnly {
+				err = os.MkdirAll(filepath.Dir(destination), os.ModePerm)
+				if err != nil {
+					return fmt.Errorf("failed to setup linked module directory scaffolding: %w", err)
+				}
 
-			err = fs.Copy(source, destination)
-			if err != nil {
-				return fmt.Errorf("failed to copy linked module directory to layer path: %w", err)
+				err = fs.Copy(source, destination)
+				if err != nil {
+					return fmt.Errorf("failed to copy linked module directory to layer path: %w", err)
+				}
 			}
 
 			err = r.linker.WithPath(pkg.Resolved).Link(source, destination)


### PR DESCRIPTION
This ensures that linked packages discovered in package-lock.json after reusing a pre-existing node_modules are symlinked correctly.

## Summary
At build time, the package-lock.json is inspected for linked packages; and symlinks (to /tmp) are set up to allow run-time injection.  At rebuild time, this step was missed.  This change fixes that.

## Use Cases
Issue #765 could be fixed by this, at least my comment on that issue is fixed by this. 

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).

I will prepare an integration test shortly.